### PR TITLE
#2 add warning about fail2ban firewalll rules detected

### DIFF
--- a/firewall/index.cgi
+++ b/firewall/index.cgi
@@ -50,6 +50,7 @@ if (!$config{'direct'} && &foreign_check("init")) {
 @livetables = &get_iptables_save("iptables-save 2>/dev/null |");
 &shorewall_message(\@livetables);
 &firewalld_message(\@livetables);
+&fail2ban_message(\@livetables);
 if (!$config{'direct'} &&
     (!-s $iptables_save_file || $in{'reset'}) && $access{'setup'}) {
 	@tables = @livetables;
@@ -429,5 +430,15 @@ if ($filter->{'defaults'}->{'INPUT_ZONES'}) {
 	      &text('index_firewalld', "$gconfig{'webprefix'}/firewalld/"),
 	      "</b></center><p>\n";
 	}
+}
+
+sub fail2ban_message
+{
+local ($filter) = grep { $_->{'name'} eq 'filter' } @{$_[0]};
+if ($filter->{'defaults'} ~~ /^f2b-|^fail2ban-/) {
+        print "<b><center>",
+              &text('index_fail2ban', "$gconfig{'webprefix'}/fail2ban/"),
+              "</b></center><p>\n";
+        }
 }
 

--- a/firewall/lang/de
+++ b/firewall/lang/de
@@ -191,6 +191,7 @@ index_ecommand=Der Befehl $1 wurde nicht auf Ihrem System gefunden. Webmin ben&#
 index_editing=Regel Datei $1
 index_ekernel=Ein Fehler ist beim &#220;berpr&#252;fen Ihrer aktuellen IPtables-Konfiguration aufgetreten : $1 Dies k&#246;nnte darauf hindeuten, dass Ihr Kernel IPtables nicht unterst&#252;tzt.
 index_existing=Webmin hat erkannt, dass $1 IPtables Firewall-Regel(n) derzeit in Benutzung sind, die nicht in der Datei $2 gespeichert wurden. Diese Regeln wurden vermutlich von einem Skript einrichtet, jedoch dieses Modul nicht in der Lage ist, dieses zu lesen und zu bearbeiten.<p>Wenn Sie dieses Modul benutzen wollen, um Ihre IPtables-Firewall verwalten zu lassen, klicken Sie auf die Schaltfl&#228;che unten, um die bestehenden Regeln zu einer Sicherungsdatei zu konvertieren und anschlie&#223;end Ihr bestehendes Firewall-Skript zu deaktivieren.
+index_fail2ban=Warnung! Es scheint, dass Fail2ban verwendet wird, um das Firewall-System zu generieren. Vielleicht sollten Sie die <a href='$1'>Fail2Ban-Modul</a> verwenden.
 index_firewalld=Warnung! Es scheint, dass FirewallD verwendet wird, um das Firewall-System zu generieren. Vielleicht sollten Sie die <a href='$1'>FirewallD Firewall-Modul</a> verwenden.
 index_header=Firewall Konfiguration von $1
 index_headerex=Bestehende Firewall Konfiguration

--- a/firewall/lang/en
+++ b/firewall/lang/en
@@ -69,6 +69,7 @@ index_auto=Setup Firewall
 index_add=Add
 index_shorewall=Warning! It appears that Shorewall is being used to generate your system's firewall. Maybe you should use the <a href='$1'>Shoreline Firewall module</a> instead.
 index_firewalld=Warning! It appears that FirewallD is being used to generate your system's firewall. Maybe you should use the <a href='$1'>FirewallD module</a> instead.
+index_fail2ban=Warning! It appears that Fail2Ban is being used to generate your system's firewall. Maybe you should use the <a href='$1'>Fail2Ban module</a> instead.
 index_reset=Reset Firewall
 index_resetdesc=Click this button to clear all existing firewall rules and set up new rules for a basic initial configuration.
 index_cluster=Cluster Servers


### PR DESCRIPTION
next try :-)

while thinking about to filter chains I investigated how to index.cgi handle tables and chains.
if fail2ban is in use admin should be careful about mangling rules by hand, so I implemented a warning for fail2ban smilar to shorewall and firewalld.